### PR TITLE
Upgrade to support platform 3.x

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,27 +21,14 @@
 			<artifactId>openmrs-api</artifactId>
 			<type>jar</type>
 		</dependency>
-		
-		<dependency>
-			<groupId>org.openmrs.web</groupId>
-			<artifactId>openmrs-web</artifactId>
-			<type>jar</type>
-		</dependency>
-				
+
 		<dependency>
 			<groupId>org.openmrs.api</groupId>
 			<artifactId>openmrs-api</artifactId>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-		
-		<dependency>
-			<groupId>org.openmrs.web</groupId>
-			<artifactId>openmrs-web</artifactId>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-		
+
 		<dependency>
 			<groupId>org.openmrs.test</groupId>
 			<artifactId>openmrs-test</artifactId>
@@ -54,7 +41,6 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.0</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/api/src/main/java/org/openmrs/calculation/CalculationRegistrationValidator.java
+++ b/api/src/main/java/org/openmrs/calculation/CalculationRegistrationValidator.java
@@ -13,7 +13,7 @@
  */
 package org.openmrs.calculation;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.calculation.api.CalculationRegistrationService;

--- a/api/src/main/java/org/openmrs/calculation/ClasspathCalculationProvider.java
+++ b/api/src/main/java/org/openmrs/calculation/ClasspathCalculationProvider.java
@@ -13,7 +13,7 @@
  */
 package org.openmrs.calculation;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.springframework.stereotype.Component;

--- a/api/src/main/java/org/openmrs/calculation/InvalidParameterValueException.java
+++ b/api/src/main/java/org/openmrs/calculation/InvalidParameterValueException.java
@@ -13,7 +13,7 @@
  */
 package org.openmrs.calculation;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.calculation.parameter.ParameterDefinition;
 

--- a/api/src/main/java/org/openmrs/calculation/MissingParameterException.java
+++ b/api/src/main/java/org/openmrs/calculation/MissingParameterException.java
@@ -13,7 +13,7 @@
  */
 package org.openmrs.calculation;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.calculation.parameter.ParameterDefinition;
 

--- a/api/src/main/java/org/openmrs/calculation/db/HibernateCalculationRegistrationDAO.java
+++ b/api/src/main/java/org/openmrs/calculation/db/HibernateCalculationRegistrationDAO.java
@@ -14,119 +14,164 @@
 package org.openmrs.calculation.db;
 
 import java.util.List;
+import java.util.Locale;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hibernate.Criteria;
-import org.hibernate.criterion.MatchMode;
-import org.hibernate.criterion.Restrictions;
-import org.openmrs.api.db.hibernate.DbSession;
-import org.openmrs.api.db.hibernate.DbSessionFactory;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.calculation.CalculationRegistration;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * It is a default implementation of {@link CalculationRegistrationDAO}.
+ * Default implementation of {@link CalculationRegistrationDAO}.
  */
 public class HibernateCalculationRegistrationDAO implements CalculationRegistrationDAO {
-	
-	protected final Log log = LogFactory.getLog(this.getClass());
-	
-	private DbSessionFactory sessionFactory;
-	
-	/**
-	 * @param sessionFactory the sessionFactory to set
-	 */
-	public void setSessionFactory(DbSessionFactory sessionFactory) {
-		this.sessionFactory = sessionFactory;
-	}
-	
-	/**
-	 * @return the session
-	 */
-	private DbSession getCurrentSession() {
-		return sessionFactory.getCurrentSession();
-	}
-	
-	/**
-	 * @see org.openmrs.calculation.db.CalculationRegistrationDAO#getCalculationRegistration(java.lang.Integer)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public CalculationRegistration getCalculationRegistration(Integer calculationRegistrationId) {
-		return (CalculationRegistration) getCurrentSession().get(CalculationRegistration.class, calculationRegistrationId);
-	}
-	
-	/**
-	 * @see org.openmrs.calculation.db.CalculationRegistrationDAO#getCalculationRegistrationByUuid(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public CalculationRegistration getCalculationRegistrationByUuid(String uuid) {
-		return (CalculationRegistration) getCurrentSession().createQuery("FROM CalculationRegistration tr WHERE tr.uuid = :uuid")
-		        .setString("uuid", uuid).uniqueResult();
-	}
-	
-	/**
-	 * @see org.openmrs.calculation.db.CalculationRegistrationDAO#getCalculationRegistrationByToken(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public CalculationRegistration getCalculationRegistrationByToken(String token) {
-		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(CalculationRegistration.class);
-		criteria.add(Restrictions.ilike("token", token, MatchMode.EXACT));
-		return (CalculationRegistration) criteria.uniqueResult();
-	}
-	
-	/**
-	 * @see org.openmrs.calculation.db.CalculationRegistrationDAO#getAllCalculationRegistrations()
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	@Transactional(readOnly = true)
-	public List<CalculationRegistration> getAllCalculationRegistrations() {
-		return getCurrentSession().createCriteria(CalculationRegistration.class).list();
-	}
 
-	/**
-	 * @see CalculationRegistrationDAO#getCalculationRegistrationsByProviderClassname(String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<CalculationRegistration> getCalculationRegistrationsByProviderClassname(String providerClassname) {
-		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(CalculationRegistration.class);
-		criteria.add(Restrictions.eq("providerClassName", providerClassname));
-		return criteria.list();
-	}
+    protected final Log log = LogFactory.getLog(this.getClass());
 
-	/**
-	 * @see org.openmrs.calculation.db.CalculationRegistrationDAO#findCalculationRegistrations(java.lang.String)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	@Transactional(readOnly = true)
-	public List<CalculationRegistration> findCalculationRegistrations(String partialToken) {
-		Criteria criteria = getCurrentSession().createCriteria(CalculationRegistration.class);
-		criteria.add(Restrictions.ilike("token", partialToken, MatchMode.ANYWHERE));
-		return criteria.list();
-	}
-	
-	/**
-	 * @see org.openmrs.calculation.db.CalculationRegistrationDAO#saveCalculationRegistration(org.openmrs.calculation.CalculationRegistration)
-	 */
-	@Override
-	@Transactional
-	public CalculationRegistration saveCalculationRegistration(CalculationRegistration calculationRegistration) {
-		getCurrentSession().saveOrUpdate(calculationRegistration);
-		return calculationRegistration;
-	}
-	
-	/**
-	 * @see org.openmrs.calculation.db.CalculationRegistrationDAO#deleteCalculationRegistration(org.openmrs.calculation.CalculationRegistration)
-	 */
-	@Override
-	@Transactional
-	public void deleteCalculationRegistration(CalculationRegistration calculationRegistration) {
-		getCurrentSession().delete(calculationRegistration);
-	}
+    private static final String TOKEN = "token";
+
+    private static final String PROVIDER_CLASS_NAME = "providerClassName";
+
+    private final SessionFactory sessionFactory;
+
+    public HibernateCalculationRegistrationDAO(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    /**
+     * @return the current Hibernate session
+     */
+    private Session getCurrentSession() {
+        return sessionFactory.getCurrentSession();
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#getCalculationRegistration(Integer)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public CalculationRegistration getCalculationRegistration(Integer calculationRegistrationId) {
+        return getCurrentSession().find(CalculationRegistration.class, calculationRegistrationId);
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#getCalculationRegistrationByUuid(String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public CalculationRegistration getCalculationRegistrationByUuid(String uuid) {
+        return HibernateUtil.getUniqueEntityByUUID(sessionFactory, CalculationRegistration.class, uuid);
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#getCalculationRegistrationByToken(String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public CalculationRegistration getCalculationRegistrationByToken(String token) {
+        Session session = getCurrentSession();
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaQuery<CalculationRegistration> query = builder.createQuery(CalculationRegistration.class);
+        Root<CalculationRegistration> root = query.from(CalculationRegistration.class);
+
+        query.select(root)
+                .where(builder.equal(
+                        builder.lower(root.get(TOKEN)),
+                        token.toLowerCase(Locale.ROOT)
+                ));
+
+        return session.createQuery(query).uniqueResult();
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#getAllCalculationRegistrations()
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<CalculationRegistration> getAllCalculationRegistrations() {
+        Session session = getCurrentSession();
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaQuery<CalculationRegistration> query = builder.createQuery(CalculationRegistration.class);
+        Root<CalculationRegistration> root = query.from(CalculationRegistration.class);
+
+        query.select(root);
+
+        return session.createQuery(query).getResultList();
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#getCalculationRegistrationsByProviderClassname(String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<CalculationRegistration> getCalculationRegistrationsByProviderClassname(String providerClassname) {
+        Session session = getCurrentSession();
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaQuery<CalculationRegistration> query = builder.createQuery(CalculationRegistration.class);
+        Root<CalculationRegistration> root = query.from(CalculationRegistration.class);
+
+        query.select(root)
+                .where(builder.equal(root.get(PROVIDER_CLASS_NAME), providerClassname));
+
+        return session.createQuery(query).getResultList();
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#findCalculationRegistrations(String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<CalculationRegistration> findCalculationRegistrations(String partialToken) {
+        Session session = getCurrentSession();
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaQuery<CalculationRegistration> query = builder.createQuery(CalculationRegistration.class);
+        Root<CalculationRegistration> root = query.from(CalculationRegistration.class);
+
+        query.select(root)
+                .where(builder.like(
+                        builder.lower(root.get(TOKEN)),
+                        containsIgnoreCasePattern(partialToken)
+                ));
+
+        return session.createQuery(query).getResultList();
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#saveCalculationRegistration(CalculationRegistration)
+     */
+    @Override
+    @Transactional
+    public CalculationRegistration saveCalculationRegistration(
+            CalculationRegistration calculationRegistration) {
+        return HibernateUtil.saveOrUpdate(
+                getCurrentSession(),
+                calculationRegistration
+        );
+    }
+
+    /**
+     * @see CalculationRegistrationDAO#deleteCalculationRegistration(CalculationRegistration)
+     */
+    @Override
+    @Transactional
+    public void deleteCalculationRegistration(CalculationRegistration calculationRegistration) {
+        Session session = getCurrentSession();
+
+        CalculationRegistration managedCalculationRegistration = session.contains(calculationRegistration)
+                ? calculationRegistration
+                : session.merge(calculationRegistration);
+
+        session.remove(managedCalculationRegistration);
+    }
+
+    private String containsIgnoreCasePattern(String value) {
+        return "%" + value.toLowerCase(Locale.ROOT) + "%";
+    }
 }

--- a/api/src/main/java/org/openmrs/calculation/patient/PatientCalculationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/calculation/patient/PatientCalculationServiceImpl.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -1,12 +1,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-           http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd">
-  		    
-	<context:component-scan base-package="@MODULE_PACKAGE@" />
+           http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="patientCalculationService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager">
@@ -61,7 +56,7 @@
 	</bean>
 	
 	<bean id="calculationRegistrationDao" class="org.openmrs.${project.parent.artifactId}.db.HibernateCalculationRegistrationDAO">
-		<property name="sessionFactory" ref="dbSessionFactory" />
+		<constructor-arg name="sessionFactory" ref="sessionFactory" />
 	</bean>
 	
 </beans>

--- a/api/src/test/java/org/openmrs/calculation/CalculationActivatorTest.java
+++ b/api/src/test/java/org/openmrs/calculation/CalculationActivatorTest.java
@@ -1,15 +1,15 @@
 package org.openmrs.calculation;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.calculation.api.CalculationRegistrationService;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class CalculationActivatorTest extends BaseModuleContextSensitiveTest {
@@ -20,7 +20,7 @@ public class CalculationActivatorTest extends BaseModuleContextSensitiveTest {
 	@Autowired
 	ImplementationConfiguredCalculationProvider provider;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		File groovyDef = new File(getClass().getClassLoader().getResource("implconfig/weight.groovy").getPath());
 		provider.setDirectory(groovyDef.getParentFile());

--- a/api/src/test/java/org/openmrs/calculation/CalculationRegistrationValidatorTest.java
+++ b/api/src/test/java/org/openmrs/calculation/CalculationRegistrationValidatorTest.java
@@ -13,16 +13,19 @@
  */
 package org.openmrs.calculation;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.calculation.api.CalculationRegistrationService;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contains tests for {@link CalculationRegistrationValidator} class.
@@ -35,7 +38,7 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 	
 	private static final String MODULE_TEST_DATA_XML = TEST_DATA_PATH + "moduleTestData.xml";
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		calculationRegistrationService = Context.getService(CalculationRegistrationService.class);
 		executeDataSet(MODULE_TEST_DATA_XML);
@@ -53,7 +56,7 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 		calculationRegistration.setCalculationName(" ");
 		Errors errors = new BindException(calculationRegistration, "calculationRegistration");
 		new CalculationRegistrationValidator().validate(calculationRegistration, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors("calculationName"));
+        assertTrue(errors.hasFieldErrors("calculationName"));
 	}
 	
 	/**
@@ -68,7 +71,7 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 		calculationRegistration.setCalculationName("A1");
 		Errors errors = new BindException(calculationRegistration, "calculationRegistration");
 		new CalculationRegistrationValidator().validate(calculationRegistration, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors("token"));
+        assertTrue(errors.hasFieldErrors("token"));
 	}
 	
 	/**
@@ -81,7 +84,7 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 		calculationRegistration.setToken("age");
 		Errors errors = new BindException(calculationRegistration, "calculationRegistration");
 		new CalculationRegistrationValidator().validate(calculationRegistration, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors("token"));
+        assertTrue(errors.hasFieldErrors("token"));
 	}
 	
 	/**
@@ -96,7 +99,7 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 		calculationRegistration.setCalculationName("A1");
 		Errors errors = new BindException(calculationRegistration, "calculationRegistration");
 		new CalculationRegistrationValidator().validate(calculationRegistration, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors("providerClassName"));
+        assertTrue(errors.hasFieldErrors("providerClassName"));
 	}
 	
 	/**
@@ -108,7 +111,7 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 		CalculationRegistration calculationRegistration = calculationRegistrationService.getCalculationRegistration(1);
 		Errors errors = new BindException(calculationRegistration, "calculationRegistration");
 		new CalculationRegistrationValidator().validate(calculationRegistration, errors);
-		Assert.assertEquals(false, errors.hasFieldErrors("token"));
+        assertFalse(errors.hasFieldErrors("token"));
 	}
 	
 	/**
@@ -123,7 +126,7 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 		calculationRegistration.setCalculationName(AgeCalculation.class.getName());
 		Errors errors = new BindException(calculationRegistration, "calculationRegistration");
 		new CalculationRegistrationValidator().validate(calculationRegistration, errors);
-		Assert.assertEquals(false, errors.hasErrors());
+        assertFalse(errors.hasErrors());
 	}
 	
 	/**
@@ -138,6 +141,6 @@ public class CalculationRegistrationValidatorTest extends BaseModuleContextSensi
 		calculationRegistration.setCalculationName("org.invalid.calculationClassName");
 		Errors errors = new BindException(calculationRegistration, "calculationRegistration");
 		new CalculationRegistrationValidator().validate(calculationRegistration, errors);
-		Assert.assertEquals(true, errors.hasErrors());
+        assertTrue(errors.hasErrors());
 	}
 }

--- a/api/src/test/java/org/openmrs/calculation/CalculationUtilTest.java
+++ b/api/src/test/java/org/openmrs/calculation/CalculationUtilTest.java
@@ -16,14 +16,19 @@ package org.openmrs.calculation;
 import java.util.Date;
 import java.util.Locale;
 
-import junit.framework.Assert;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.Patient;
 import org.openmrs.Person;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contains test methods for {@link CalculationUtilTest}
@@ -40,14 +45,14 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "return true for primitive type wrapper class names", method = "isPrimitiveWrapperClassName(String)")
 	public void isPrimitiveWrapperClassName_shouldReturnTrueForPrimitiveTypeWrapperClassNames() throws Exception {
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Boolean"));
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Character"));
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Byte"));
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Short"));
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Integer"));
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Float"));
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Double"));
-		Assert.assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Long"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Boolean"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Character"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Byte"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Short"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Integer"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Float"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Double"));
+		assertTrue(CalculationUtil.isPrimitiveWrapperClassName("java.lang.Long"));
 	}
 	
 	/**
@@ -56,7 +61,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a character value to Character", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertACharacterValueToCharacter() throws Exception {
-		Assert.assertEquals('c', CalculationUtil.cast("c", Character.class).charValue());
+		assertEquals('c', CalculationUtil.cast("c", Character.class).charValue());
 	}
 	
 	/**
@@ -65,7 +70,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a result with an number value in the valid range to byte", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAResultWithAnNumberValueInTheValidRangeToByte() throws Exception {
-		Assert.assertEquals(127, CalculationUtil.cast(127, Byte.class).byteValue());
+		assertEquals(127, CalculationUtil.cast(127, Byte.class).byteValue());
 	}
 	
 	/**
@@ -74,7 +79,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a single character value to Short", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertASingleCharacterValueToShort() throws Exception {
-		Assert.assertEquals(2, CalculationUtil.cast('2', Short.class).shortValue());
+		assertEquals(2, CalculationUtil.cast('2', Short.class).shortValue());
 	}
 	
 	/**
@@ -83,7 +88,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid single character value to Integer", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidSingleCharacterValueToInteger() throws Exception {
-		Assert.assertEquals(2, CalculationUtil.cast('2', Integer.class).intValue());
+		assertEquals(2, CalculationUtil.cast('2', Integer.class).intValue());
 	}
 	
 	/**
@@ -92,7 +97,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid single character value to Long", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidSingleCharacterValueToLong() throws Exception {
-		Assert.assertEquals(2, CalculationUtil.cast('2', Long.class).longValue());
+		assertEquals(2, CalculationUtil.cast('2', Long.class).longValue());
 	}
 	
 	/**
@@ -101,8 +106,8 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string value to Boolean", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringValueToBoolean() throws Exception {
-		Assert.assertEquals(true, CalculationUtil.cast("true", Boolean.class).booleanValue());
-		Assert.assertEquals(false, CalculationUtil.cast("false", Boolean.class).booleanValue());
+        assertTrue(CalculationUtil.cast("true", Boolean.class).booleanValue());
+        assertFalse(CalculationUtil.cast("false", Boolean.class).booleanValue());
 	}
 	
 	/**
@@ -111,7 +116,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string value to Byte", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringValueToByte() throws Exception {
-		Assert.assertEquals(2, CalculationUtil.cast("2", Byte.class).byteValue());
+		assertEquals(2, CalculationUtil.cast("2", Byte.class).byteValue());
 	}
 	
 	/**
@@ -120,7 +125,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string value to Double", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringValueToDouble() throws Exception {
-		Assert.assertEquals(1.7976931348623157e+308, CalculationUtil.cast("1.7976931348623157e+308", Double.class)
+		assertEquals(1.7976931348623157e+308, CalculationUtil.cast("1.7976931348623157e+308", Double.class)
 		        .doubleValue());
 	}
 	
@@ -130,7 +135,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string value to Float", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringValueToFloat() throws Exception {
-		Assert.assertEquals(3.4028235e+1f, CalculationUtil.cast("3.4028235e+1f", Float.class).floatValue());
+		assertEquals(3.4028235e+1f, CalculationUtil.cast("3.4028235e+1f", Float.class).floatValue());
 	}
 	
 	/**
@@ -139,7 +144,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string value to Integer", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringValueToInteger() throws Exception {
-		Assert.assertEquals(122, CalculationUtil.cast("122", Integer.class).intValue());
+		assertEquals(122, CalculationUtil.cast("122", Integer.class).intValue());
 	}
 	
 	/**
@@ -148,7 +153,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string value to Long", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringValueToLong() throws Exception {
-		Assert.assertEquals(122, CalculationUtil.cast("122", Long.class).longValue());
+		assertEquals(122, CalculationUtil.cast("122", Long.class).longValue());
 	}
 	
 	/**
@@ -157,7 +162,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string value to Short", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringValueToShort() throws Exception {
-		Assert.assertEquals(122, CalculationUtil.cast("122", Short.class).shortValue());
+		assertEquals(122, CalculationUtil.cast("122", Short.class).shortValue());
 	}
 	
 	/**
@@ -167,17 +172,17 @@ public class CalculationUtilTest {
 	@Verifies(value = "should convert the value to the specified type if it is compatible", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertTheValueToTheSpecifiedTypeIfItIsCompatible() throws Exception {
 		Person convertedObject = CalculationUtil.cast(new Patient(), Person.class);
-		Assert.assertNotNull(convertedObject);
-		Assert.assertTrue(Person.class.isAssignableFrom(convertedObject.getClass()));
+		assertNotNull(convertedObject);
+		assertTrue(Person.class.isAssignableFrom(convertedObject.getClass()));
 	}
 	
 	/**
 	 * @see {@link CalculationUtil#cast(Object,Class<T>)}
 	 */
-	@Test(expected = ConversionException.class)
+	@Test
 	@Verifies(value = "should fail if the value to convert is not of a compatible type", method = "cast(Object,Class<T>)")
 	public void cast_shouldFailIfTheValueToConvertIsNotOfACompatibleType() throws Exception {
-		CalculationUtil.cast(new Person(), Patient.class);
+		assertThrows(ConversionException.class, () -> CalculationUtil.cast(new Person(), Patient.class));
 	}
 	
 	/**
@@ -186,7 +191,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should return null if the passed in value is null", method = "cast(Object,Class<T>)")
 	public void cast_shouldReturnNullIfThePassedInValueIsNull() throws Exception {
-		Assert.assertNull(CalculationUtil.cast(null, null));
+		assertNull(CalculationUtil.cast(null, null));
 	}
 	
 	/**
@@ -195,7 +200,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string to a class object", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringToAClassObject() throws Exception {
-		Assert.assertEquals(Concept.class, CalculationUtil.cast("org.openmrs.Concept", Class.class));
+		assertEquals(Concept.class, CalculationUtil.cast("org.openmrs.Concept", Class.class));
 	}
 	
 	/**
@@ -204,7 +209,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string to a Locale", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringToALocale() throws Exception {
-		Assert.assertEquals(Locale.US, CalculationUtil.cast("en_US", Locale.class));
+		assertEquals(Locale.US, CalculationUtil.cast("en_US", Locale.class));
 	}
 	
 	/**
@@ -213,7 +218,7 @@ public class CalculationUtilTest {
 	@Test
 	@Verifies(value = "should convert a valid string to an enum constant", method = "cast(Object,Class<T>)")
 	public void cast_shouldConvertAValidStringToAnEnumConstant() throws Exception {
-		Assert.assertEquals(Geek.NERD, CalculationUtil.cast("NERD", Geek.class));
+		assertEquals(Geek.NERD, CalculationUtil.cast("NERD", Geek.class));
 	}
 	
 	/**
@@ -223,6 +228,6 @@ public class CalculationUtilTest {
 	@Verifies(value = "should format a date object to a string using the default date format", method = "cast(Object,Class<QT;>)")
 	public void cast_shouldFormatADateObjectToAStringUsingTheDefaultDateFormat() throws Exception {
 		Date date = new Date();
-		Assert.assertEquals(Context.getDateFormat().format(date), CalculationUtil.cast(date, String.class));
+		assertEquals(Context.getDateFormat().format(date), CalculationUtil.cast(date, String.class));
 	}
 }

--- a/api/src/test/java/org/openmrs/calculation/ClasspathCalculationProviderTest.java
+++ b/api/src/test/java/org/openmrs/calculation/ClasspathCalculationProviderTest.java
@@ -13,10 +13,13 @@
  */
 package org.openmrs.calculation;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.junit.jupiter.api.Test;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.openmrs.test.Verifies;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests the ClasspathCalculationProvider
@@ -32,7 +35,7 @@ public class ClasspathCalculationProviderTest extends BaseModuleContextSensitive
 	    throws Exception {
 		ClasspathCalculationProvider p = new ClasspathCalculationProvider();
 		Calculation c = p.getCalculation(MostRecentObsCalculation.class.getName(), "5089");
-		Assert.assertNotNull(c);
+		assertNotNull(c);
 	}
 	
 	/**
@@ -43,18 +46,19 @@ public class ClasspathCalculationProviderTest extends BaseModuleContextSensitive
 	public void getCalculation_shouldRetrieveANonConfigurableCalculationWithANullConfigurationString() throws Exception {
 		ClasspathCalculationProvider p = new ClasspathCalculationProvider();
 		Calculation c = p.getCalculation(AgeCalculation.class.getName(), null);
-		Assert.assertNotNull(c);
+		assertNotNull(c);
 	}
 	
 	/**
 	 * @see ClasspathCalculationProvider#getCalculation(String,String)
 	 * @verifies throw an exception if a configurable calculation is passed an illegal configuration
 	 */
-	@Test(expected = InvalidCalculationException.class)
+	@Test
 	public void getCalculation_shouldThrowAnExceptionIfAConfigurableCalculationIsPassedAnIllegalConfiguration()
 	    throws Exception {
 		ClasspathCalculationProvider p = new ClasspathCalculationProvider();
-		p.getCalculation(MostRecentObsCalculation.class.getName(), "5o89");
+		assertThrows(InvalidCalculationException.class,
+		    () -> p.getCalculation(MostRecentObsCalculation.class.getName(), "5o89"));
 	}
 	
 	/**
@@ -62,11 +66,12 @@ public class ClasspathCalculationProviderTest extends BaseModuleContextSensitive
 	 * @verifies throw an exception if a non configurable calculation is passed a configuration
 	 *           string
 	 */
-	@Test(expected = InvalidCalculationException.class)
+	@Test
 	public void getCalculation_shouldThrowAnExceptionIfANonConfigurableCalculationIsPassedAConfigurationString()
 	    throws Exception {
 		ClasspathCalculationProvider p = new ClasspathCalculationProvider();
-		p.getCalculation(AgeCalculation.class.getName(), "something");
+		assertThrows(InvalidCalculationException.class,
+		    () -> p.getCalculation(AgeCalculation.class.getName(), "something"));
 	}
 	
 	/**
@@ -77,6 +82,6 @@ public class ClasspathCalculationProviderTest extends BaseModuleContextSensitive
 	public void getCalculation_shouldAlwaysReturnADifferentInstanceOfACalculation() throws Exception {
 		ClasspathCalculationProvider p = new ClasspathCalculationProvider();
 		String calculationName = InnerCalculation.class.getName();
-		Assert.assertTrue(p.getCalculation(calculationName, null) != p.getCalculation(calculationName, null));
+        assertNotSame(p.getCalculation(calculationName, null), p.getCalculation(calculationName, null));
 	}
 }

--- a/api/src/test/java/org/openmrs/calculation/ImplementationConfiguredCalculationProviderTest.java
+++ b/api/src/test/java/org/openmrs/calculation/ImplementationConfiguredCalculationProviderTest.java
@@ -1,20 +1,20 @@
 package org.openmrs.calculation;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.calculation.patient.PatientCalculation;
 import org.openmrs.calculation.patient.PatientCalculationService;
 import org.openmrs.calculation.result.CalculationResult;
 import org.openmrs.calculation.result.SimpleResult;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class ImplementationConfiguredCalculationProviderTest extends BaseModuleContextSensitiveTest {
@@ -25,7 +25,7 @@ public class ImplementationConfiguredCalculationProviderTest extends BaseModuleC
 	@Autowired
 	PatientCalculationService service;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		File groovyDef = new File(getClass().getClassLoader().getResource("implconfig/weight.groovy").getPath());
 		provider.setDirectory(groovyDef.getParentFile());

--- a/api/src/test/java/org/openmrs/calculation/api/CalculationRegistrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/calculation/api/CalculationRegistrationServiceTest.java
@@ -13,16 +13,16 @@
  */
 package org.openmrs.calculation.api;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.calculation.AgeCalculation;
 import org.openmrs.calculation.CalculationRegistration;
 import org.openmrs.calculation.MostRecentObsCalculation;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.openmrs.test.Verifies;
 
 /**
@@ -38,7 +38,7 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	
 	private CalculationRegistrationService service;
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		executeDataSet(MODULE_TEST_DATA_XML);
 		service = Context.getService(CalculationRegistrationService.class);
@@ -50,7 +50,7 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	@Test
 	@Verifies(value = "should return a token with a matching id", method = "getCalculationRegistration(Integer)")
 	public void getCalculationRegistration_shouldReturnATokenWithAMatchingId() throws Exception {
-		Assert.assertEquals(TOKEN_UUID, service.getCalculationRegistration(1).getUuid());
+		Assertions.assertEquals(TOKEN_UUID, service.getCalculationRegistration(1).getUuid());
 	}
 	
 	/**
@@ -59,7 +59,7 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	@Test
 	@Verifies(value = "should fetch a token with a matching uuid", method = "getCalculationRegistrationByUuid(Integer)")
 	public void getCalculationRegistrationByUuid_shouldFetchATokenWithAMatchingUuid() throws Exception {
-		Assert.assertEquals("age", service.getCalculationRegistrationByUuid(TOKEN_UUID).getToken());
+		Assertions.assertEquals("age", service.getCalculationRegistrationByUuid(TOKEN_UUID).getToken());
 	}
 	
 	/**
@@ -68,7 +68,7 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	@Test
 	@Verifies(value = "should get all tokens in the database", method = "getAllCalculationRegistrations()")
 	public void getAllCalculationRegistrations_shouldGetAllTokensInTheDatabase() throws Exception {
-		Assert.assertEquals(3, service.getAllCalculationRegistrations().size());
+		Assertions.assertEquals(3, service.getAllCalculationRegistrations().size());
 	}
 	
 	/**
@@ -83,8 +83,8 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 		token.setProviderClassName("org.openmrs.calculation.ClasspathCalculationProvider");
 		token.setCalculationName("org.openmrs.calculation.AgeCalculation");
 		service.saveCalculationRegistration(token);
-		Assert.assertNotNull(token.getId());
-		Assert.assertEquals(originalTokenCount + 1, service.getAllCalculationRegistrations().size());
+		Assertions.assertNotNull(token.getId());
+		Assertions.assertEquals(originalTokenCount + 1, service.getAllCalculationRegistrations().size());
 	}
 	
 	/**
@@ -95,9 +95,9 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	public void purgeCalculationRegistration_shouldPurgeTheSpecifiedCalculationRegistrationFromTheDatabase()
 	    throws Exception {
 		CalculationRegistration token = service.getCalculationRegistrationByUuid(TOKEN_UUID);
-		Assert.assertNotNull(service.getCalculationRegistrationByUuid(TOKEN_UUID));//control check
+		Assertions.assertNotNull(service.getCalculationRegistrationByUuid(TOKEN_UUID));//control check
 		service.purgeCalculationRegistration(token);
-		Assert.assertNull(service.getCalculationRegistrationByUuid(TOKEN_UUID));
+		Assertions.assertNull(service.getCalculationRegistrationByUuid(TOKEN_UUID));
 	}
 	
 	/**
@@ -108,12 +108,12 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	public void saveCalculationRegistration_shouldUpdateAnExistingToken() throws Exception {
 		String newTokenName = "new test token name";
 		CalculationRegistration token = service.getCalculationRegistrationByUuid(TOKEN_UUID);
-		Assert.assertNotSame(newTokenName, token.getToken());
+		Assertions.assertNotSame(newTokenName, token.getToken());
 		
 		token.setToken(newTokenName);
 		service.saveCalculationRegistration(token);
 		
-		Assert.assertSame(newTokenName, token.getToken());
+		Assertions.assertSame(newTokenName, token.getToken());
 	}
 	
 	/**
@@ -124,8 +124,8 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	public void getCalculation_shouldReturnTheCalculationAssociatedToTheCalculationRegistrationWithTheGivenName()
 	    throws Exception {
 		MostRecentObsCalculation calculation = service.getCalculation("mostRecentCD4", MostRecentObsCalculation.class);
-		Assert.assertNotNull(calculation);
-		Assert.assertEquals(5497, calculation.getWhichConcept().getConceptId().intValue());
+		Assertions.assertNotNull(calculation);
+		Assertions.assertEquals(5497, calculation.getWhichConcept().getConceptId().intValue());
 	}
 	
 	/**
@@ -134,7 +134,7 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	@Test
 	@Verifies(value = "should get all calculationRegistrations with a matching name", method = "findCalculationRegistrations(String)")
 	public void findCalculationRegistrations_shouldGetAllCalculationRegistrationsWithAMatchingName() throws Exception {
-		Assert.assertEquals(2, service.findCalculationRegistrations("mostRecent").size());
+		Assertions.assertEquals(2, service.findCalculationRegistrations("mostRecent").size());
 	}
 	
 	/**
@@ -143,13 +143,13 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 	@Test
 	@Verifies(value = "should fetch a token with a matching name", method = "getCalculationRegistrationByToken(String)")
 	public void getCalculationRegistrationByToken_shouldFetchATokenWithAMatchingName() throws Exception {
-		Assert.assertEquals(TOKEN_UUID, service.getCalculationRegistrationByToken("age").getUuid());
+		Assertions.assertEquals(TOKEN_UUID, service.getCalculationRegistrationByToken("age").getUuid());
 	}
 	
 	/**
 	 * @see {@link CalculationRegistrationService#saveCalculationRegistration(CalculationRegistration)}
 	 */
-	@Test(expected = APIException.class)
+	@Test
 	@Verifies(value = "should update the cached token registration", method = "saveCalculationRegistration(CalculationRegistration)")
 	public void saveCalculationRegistration_shouldUpdateTheCachedTokenRegistration() throws Exception {
 		final String tokenName = "age";
@@ -160,23 +160,25 @@ public class CalculationRegistrationServiceTest extends BaseModuleContextSensiti
 		CalculationRegistration originalTokenReg = service.getCalculationRegistrationByToken(tokenName);
 		try {
 			//This should lead to the token registration getting cached
-			Assert.assertNotNull(service.getCalculation(tokenName, AgeCalculation.class));
+			Assertions.assertNotNull(service.getCalculation(tokenName, AgeCalculation.class));
 			
 			//now we need to remove it from the session so that we effectively 
 			//mimic our cache and DB being out of sync when changes are made
 			Context.evictFromSession(originalTokenReg);
 		}
 		catch (APIException e) {
-			Assert.fail(e.getMessage());
+			Assertions.fail(e.getMessage());
 		}
 		
 		CalculationRegistration newTokenRegInstance = service.getCalculationRegistrationByToken(tokenName);
-		newTokenRegInstance.setCalculationName("some.unknown.Classname");
+		newTokenRegInstance.setCalculationName(MostRecentObsCalculation.class.getName());
+		newTokenRegInstance.setConfiguration("5089");
 		
 		//this should synchronize our cache with the DB
 		service.saveCalculationRegistration(newTokenRegInstance);
-		
+
 		//should fail this time because of the new unknown class
+
 		service.getCalculation(tokenName, AgeCalculation.class);
 	}
 }

--- a/api/src/test/java/org/openmrs/calculation/patient/PatientBehaviorTest.java
+++ b/api/src/test/java/org/openmrs/calculation/patient/PatientBehaviorTest.java
@@ -20,12 +20,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.openmrs.Cohort;
-import org.openmrs.Concept;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.api.PatientService;
@@ -44,7 +42,13 @@ import org.openmrs.calculation.result.CalculationResultMap;
 import org.openmrs.calculation.result.EncounterResult;
 import org.openmrs.calculation.result.ListResult;
 import org.openmrs.calculation.result.ObsResult;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contains behavior tests for patient calculations
@@ -57,7 +61,7 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 	
 	private static final String TEST_DATA_XML = "org/openmrs/calculation/include/moduleTestData.xml";
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		service = Context.getService(PatientCalculationService.class);
 	}
@@ -75,7 +79,7 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		int patientId = 2;
 		int expected = Context.getPatientService().getPatient(patientId).getAge();
 		CalculationResult calculated = getService().evaluate(patientId, ageCalculation);
-		Assert.assertEquals(expected, calculated.asType(Integer.class).intValue());
+		assertEquals(expected, calculated.asType(Integer.class).intValue());
 	}
 	
 	/**
@@ -93,7 +97,7 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		ctxt.setNow(date);
 		
 		int expected = Context.getPatientService().getPatient(patientId).getAge(date);
-		Assert.assertEquals(expected, getService().evaluate(patientId, ageCalculation, ctxt).asType(Integer.class)
+		assertEquals(expected, getService().evaluate(patientId, ageCalculation, ctxt).asType(Integer.class)
 		        .intValue());
 	}
 	
@@ -106,8 +110,8 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		PatientCalculation ageCalculation = getAgeCalculation();
 		ParameterDefinitionSet pds = ageCalculation.getParameterDefinitionSet();
 		ParameterDefinition pd = pds.getParameterByKey("units");
-		Assert.assertNotNull(pd);
-		Assert.assertEquals(pd.getName(), "Units Of Age");
+		assertNotNull(pd);
+		assertEquals("Units Of Age", pd.getName());
 		
 		int patientId = 2;
 		
@@ -117,7 +121,7 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		Map<String, Object> values = new HashMap<String, Object>();
 		values.put(pd.getKey(), "months");
 		
-		Assert.assertEquals(296, getService().evaluate(patientId, ageCalculation, values, ctxt).asType(Integer.class)
+		assertEquals(296, getService().evaluate(patientId, ageCalculation, values, ctxt).asType(Integer.class)
 		        .intValue());
 	}
 	
@@ -132,8 +136,8 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		int expected1 = ps.getPatient(patientId1).getAge();
 		int expected2 = ps.getPatient(patientId2).getAge();
 		CalculationResultMap cr = getService().evaluate(cohort, ageCalculation);
-		Assert.assertEquals(expected1, cr.get(patientId1).asType(Integer.class).intValue());
-		Assert.assertEquals(expected2, cr.get(patientId2).asType(Integer.class).intValue());
+		assertEquals(expected1, cr.get(patientId1).asType(Integer.class).intValue());
+		assertEquals(expected2, cr.get(patientId2).asType(Integer.class).intValue());
 	}
 	
 	@Test
@@ -152,8 +156,8 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		int expected2 = ps.getPatient(patientId2).getAge(date);
 		
 		CalculationResultMap cr = getService().evaluate(cohort, ageCalculation, ctxt);
-		Assert.assertEquals(expected1, cr.get(patientId1).asType(Integer.class).intValue());
-		Assert.assertEquals(expected2, cr.get(patientId2).asType(Integer.class).intValue());
+		assertEquals(expected1, cr.get(patientId1).asType(Integer.class).intValue());
+		assertEquals(expected2, cr.get(patientId2).asType(Integer.class).intValue());
 	}
 	
 	@Test
@@ -172,8 +176,8 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		values.put(pd.getKey(), "months");
 		
 		CalculationResultMap cr = getService().evaluate(cohort, ageCalculation, values, ctxt);
-		Assert.assertEquals(296, cr.get(patientId1).asType(Integer.class).intValue());
-		Assert.assertEquals(280, cr.get(patientId2).asType(Integer.class).intValue());
+		assertEquals(296, cr.get(patientId1).asType(Integer.class).intValue());
+		assertEquals(280, cr.get(patientId2).asType(Integer.class).intValue());
 	}
 	
 	@Test
@@ -185,9 +189,9 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		PatientCalculation calc = getMostRecentEncounterCalculation();
 		EncounterResult result = (EncounterResult) getService().evaluate(patientId, calc);
 		
-		Assert.assertEquals(expectedEncounter, result.asType(Encounter.class));
+		assertEquals(expectedEncounter, result.asType(Encounter.class));
 		//Since this is a date-based result, check the date
-		Assert.assertEquals(expectedEncounter.getEncounterDatetime(), result.getDateOfResult());
+		assertEquals(expectedEncounter.getEncounterDatetime(), result.getDateOfResult());
 	}
 	
 	@Test
@@ -198,8 +202,8 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		PatientCalculation calc = getMostRecentWeightCalculation();
 		ObsResult result = (ObsResult) getService().evaluate(patientId, calc);
 		
-		Assert.assertEquals(expectedObs, result.asType(Obs.class));
-		Assert.assertEquals(expectedObs.getObsDatetime(), result.getDateOfResult());
+		assertEquals(expectedObs, result.asType(Obs.class));
+		assertEquals(expectedObs.getObsDatetime(), result.getDateOfResult());
 	}
 	
 	@Test
@@ -211,18 +215,18 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		String cacheKey = MostRecentObsCalculation.class.getName() + ".Concept" + " #5089.7";
 
 		PatientCalculationContext context = getService().createCalculationContext();
-		Assert.assertTrue(context.getFromCache(cacheKey) == null);
+        assertNull(context.getFromCache(cacheKey));
 
 		//sanity check, since the cache is empty, it should return the most recent obs amongst all obs for the patient
 		PatientCalculation mostRecentObsCalculation = getMostRecentWeightCalculation();
 		ObsResult firstTestResult = (ObsResult) getService().evaluate(patientId, mostRecentObsCalculation, context);
-		Assert.assertEquals(expectedMostRecentObs, firstTestResult.asType(Obs.class));
-		Assert.assertTrue(context.getFromCache(cacheKey) == firstTestResult);
+		assertEquals(expectedMostRecentObs, firstTestResult.asType(Obs.class));
+        assertSame(context.getFromCache(cacheKey), firstTestResult);
 
 		PatientCalculation anotherMostRecentObsCalculation = getMostRecentWeightCalculation();
 		ObsResult secondTestResult = (ObsResult) getService().evaluate(patientId, anotherMostRecentObsCalculation, context);
-		Assert.assertTrue(context.getFromCache(cacheKey) == secondTestResult);
-		Assert.assertTrue(firstTestResult == secondTestResult);
+        assertSame(context.getFromCache(cacheKey), secondTestResult);
+        assertSame(firstTestResult, secondTestResult);
 	}
 	
 	@Test
@@ -236,10 +240,10 @@ public class PatientBehaviorTest extends BaseModuleContextSensitiveTest {
 		ListResult result = (ListResult) getService().evaluate(patientId, calc);
 		
 		Encounter expectedFirst = Context.getEncounterService().getEncounter(3);
-		Assert.assertEquals(expectedFirst, result.getFirstResult().asType(Encounter.class));
+		assertEquals(expectedFirst, result.getFirstResult().asType(Encounter.class));
 		
 		Encounter expectedLast = Context.getEncounterService().getEncounter(5);
-		Assert.assertEquals(expectedLast, result.getLastResult().asType(Encounter.class));
+		assertEquals(expectedLast, result.getLastResult().asType(Encounter.class));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/calculation/patient/PatientCalculationServiceTest.java
+++ b/api/src/test/java/org/openmrs/calculation/patient/PatientCalculationServiceTest.java
@@ -18,10 +18,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Cohort;
 import org.openmrs.ConceptNumeric;
 import org.openmrs.api.context.Context;
@@ -34,8 +34,12 @@ import org.openmrs.calculation.InvalidParameterValueException;
 import org.openmrs.calculation.MissingParameterException;
 import org.openmrs.calculation.parameter.ParameterDefinition;
 import org.openmrs.calculation.parameter.SimpleParameterDefinition;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.openmrs.test.Verifies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contains test methods for {@link PatientCalculationService}
@@ -48,7 +52,7 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 	
 	private static final String MODULE_TEST_DATA_XML = TEST_DATA_PATH + "moduleTestData.xml";
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		executeDataSet(MODULE_TEST_DATA_XML);
 		service = Context.getService(PatientCalculationService.class);
@@ -59,13 +63,13 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 	 *      PatientCalculationService#evaluate(Cohort,Calculation,Map<String,Object>,CalculationContext
 	 *      )}
 	 */
-	@Test(expected = MissingParameterException.class)
+	@Test
 	@Verifies(value = "should fail if any required parameter is not set", method = "evaluate(Cohort,Calculation,Map<String,Object>,CalculationContext)")
 	public void evaluate_shouldFailIfAnyRequiredParameterIsNotSet() throws Exception {
 		PatientCalculation ageCalculation = getAgeCalculation();
 		ParameterDefinition requiredDefinition = new SimpleParameterDefinition("testParam", "my data type", null, true);
 		ageCalculation.getParameterDefinitionSet().add(requiredDefinition);
-		service.evaluate(2, ageCalculation);
+		assertThrows(MissingParameterException.class, () -> service.evaluate(2, ageCalculation));
 	}
 	
 	/**
@@ -73,7 +77,7 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 	 *      PatientCalculationService#evaluate(Cohort,Calculation,Map<String,Object>,CalculationContext
 	 *      )}
 	 */
-	@Test(expected = MissingParameterException.class)
+	@Test
 	@Verifies(value = "should fail for a blank value for a required parameter if datatype is a primitive wrapper", method = "evaluate(Cohort,Calculation,Map<String,Object>,CalculationContext)")
 	public void evaluate_shouldFailForABlankValueForARequiredParameterIfDatatypeIsAPrimitiveWrapper() throws Exception {
 		PatientCalculation ageCalculation = getAgeCalculation();
@@ -82,7 +86,8 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 		
 		Map<String, Object> values = new HashMap<String, Object>();
 		values.put(requiredDefinition.getKey(), "");
-		service.evaluate(2, ageCalculation, values, null);
+		assertThrows(MissingParameterException.class,
+		    () -> service.evaluate(2, ageCalculation, values, null));
 	}
 	
 	/**
@@ -90,7 +95,7 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 	 *      PatientCalculationService#evaluate(Cohort,Calculation,Map<String,Object>,CalculationContext
 	 *      )}
 	 */
-	@Test(expected = MissingParameterException.class)
+	@Test
 	@Verifies(value = "should fail for a blank value for a required parameter if datatype is a String", method = "evaluate(Cohort,Calculation,Map<String,Object>,CalculationContext)")
 	public void evaluate_shouldFailForABlankValueForARequiredParameterIfDatatypeIsAString() throws Exception {
 		PatientCalculation ageCalculation = getAgeCalculation();
@@ -99,7 +104,8 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 		
 		Map<String, Object> values = new HashMap<String, Object>();
 		values.put(requiredDefinition.getKey(), "");
-		service.evaluate(2, ageCalculation, values, null);
+		assertThrows(MissingParameterException.class,
+		    () -> service.evaluate(2, ageCalculation, values, null));
 	}
 	
 	/**
@@ -114,7 +120,7 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 	 * @see {@link PatientCalculationService#evaluate(Cohort,PatientCalculation,Map<String,Object>,
 	 *      PatientCalculationContext)}
 	 */
-	@Test(expected = InvalidParameterValueException.class)
+	@Test
 	@Verifies(value = "should fail if the a parameter value doesnt match the allowed datatype", method = "evaluate(Cohort,PatientCalculation,Map<String,Object>,PatientCalculationContext)")
 	public void evaluate_shouldFailIfTheAParameterValueDoesntMatchTheAllowedDatatype() throws Exception {
 		PatientCalculation ageCalculation = getAgeCalculation();
@@ -123,7 +129,8 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 		
 		Map<String, Object> values = new HashMap<String, Object>();
 		values.put(param.getKey(), "2s");
-		service.evaluate(2, ageCalculation, values, null);
+		assertThrows(InvalidParameterValueException.class,
+		    () -> service.evaluate(2, ageCalculation, values, null));
 	}
 	
 	/**
@@ -153,15 +160,15 @@ public class PatientCalculationServiceTest extends BaseModuleContextSensitiveTes
 	@Verifies(value = "should return the expected result size for cohort with a large number of patient", method = "evaluate(Cohort,PatientCalculation,Map<String,Object>,PatientCalculationContext)")
 	public void evaluate_shouldReturnTheExpectedResultSizeForCohortWithALargeNumberOfPatient() throws Exception {
 		final int patientCount = 1001012;
-		Assert.assertTrue(patientCount > CalculationConstants.EVALUATION_BATCH_SIZE);
+		assertTrue(patientCount > CalculationConstants.EVALUATION_BATCH_SIZE);
 		List<Integer> cohort = new ArrayList<Integer>();
 		//create a large cohort for testing purposes
 		for (int i = 1; i <= patientCount; ++i) {
 			cohort.add(i);
 		}
 		
-		Assert.assertEquals(patientCount, service.evaluate(cohort, new CountingCalculation()).size());
+		assertEquals(patientCount, service.evaluate(cohort, new CountingCalculation()).size());
 		//the cohort members should remain unchanged
-		Assert.assertEquals(patientCount, cohort.size());
+		assertEquals(patientCount, cohort.size());
 	}
 }

--- a/api/src/test/java/org/openmrs/calculation/result/CalculationResultMapTest.java
+++ b/api/src/test/java/org/openmrs/calculation/result/CalculationResultMapTest.java
@@ -1,9 +1,12 @@
 package org.openmrs.calculation.result;
 
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.PatientProgram;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CalculationResultMapTest {
 	
@@ -14,7 +17,7 @@ public class CalculationResultMapTest {
 	@Test
 	public void getAsBoolean_shouldReturnFalseIfKeyIsNotMapped() throws Exception {
 		CalculationResultMap map = new CalculationResultMap();
-		Assert.assertFalse(map.getAsBoolean(999));
+		assertFalse(map.getAsBoolean(999));
 	}
 	
 	/**
@@ -27,7 +30,7 @@ public class CalculationResultMapTest {
 		CalculationResultMap map = new CalculationResultMap();
 		for (Object f : falsey) {
 			map.put(1, new SimpleResult(f, null));
-			Assert.assertFalse(map.getAsBoolean(1));
+			assertFalse(map.getAsBoolean(1));
 		}
 	}
 	
@@ -41,7 +44,7 @@ public class CalculationResultMapTest {
 		CalculationResultMap map = new CalculationResultMap();
 		for (Object t : truthy) {
 			map.put(1, new SimpleResult(t, null));
-			Assert.assertTrue(map.getAsBoolean(1));
+			assertTrue(map.getAsBoolean(1));
 		}
 	}
 	
@@ -52,7 +55,7 @@ public class CalculationResultMapTest {
 	@Test
 	public void isEmpty_shouldReturnTrueIfKeyIsNotMapped() throws Exception {
 		CalculationResultMap map = new CalculationResultMap();
-		Assert.assertTrue(map.isEmpty(999));
+		assertTrue(map.isEmpty(999));
 	}
 	
 	/**
@@ -65,7 +68,7 @@ public class CalculationResultMapTest {
 		CalculationResultMap map = new CalculationResultMap();
 		for (CalculationResult e : empty) {
 			map.put(1, e);
-			Assert.assertTrue(map.isEmpty(1));
+			assertTrue(map.isEmpty(1));
 		}
 	}
 	
@@ -81,7 +84,7 @@ public class CalculationResultMapTest {
 		CalculationResultMap map = new CalculationResultMap();
 		for (CalculationResult ne : notEmpty) {
 			map.put(1, ne);
-			Assert.assertFalse(map.isEmpty(1));
+			assertFalse(map.isEmpty(1));
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/calculation/result/ListResultTest.java
+++ b/api/src/test/java/org/openmrs/calculation/result/ListResultTest.java
@@ -4,8 +4,9 @@ package org.openmrs.calculation.result;
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ListResultTest {
 	
@@ -23,9 +24,9 @@ public class ListResultTest {
 		lr.add(new SimpleResult(date, null));
 		
 		List<Object> values = lr.getValues();
-		Assert.assertEquals(lr.size(), values.size());
-		Assert.assertEquals("A string", values.get(0));
-		Assert.assertEquals(Double.valueOf(2), values.get(1));
-		Assert.assertEquals(date, values.get(2));
+		assertEquals(lr.size(), values.size());
+		assertEquals("A string", values.get(0));
+		assertEquals(Double.valueOf(2), values.get(1));
+		assertEquals(date, values.get(2));
 	}
 }

--- a/api/src/test/java/org/openmrs/calculation/result/ResultUtilTest.java
+++ b/api/src/test/java/org/openmrs/calculation/result/ResultUtilTest.java
@@ -21,15 +21,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openmrs.Concept;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.Obs;
 import org.openmrs.PatientProgram;
 import org.openmrs.test.Verifies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResultUtilTest {
 	
@@ -46,7 +52,7 @@ public class ResultUtilTest {
 		listResult.setValue(results);
 		
 		CalculationResult firstResult = ResultUtil.getFirst(listResult);
-		Assert.assertEquals("first", firstResult.getValue());
+		assertEquals("first", firstResult.getValue());
 	}
 	
 	/**
@@ -56,7 +62,7 @@ public class ResultUtilTest {
 	@Verifies(value = "should return the same result if the value of the result is a not a list", method = "getFirst(CalculationResult)")
 	public void getFirst_shouldReturnTheSameResultIfTheValueOfTheResultIsANotAList() throws Exception {
 		CalculationResult result = new SimpleResult("result", null);
-		Assert.assertEquals(result, ResultUtil.getFirst(result));
+		assertEquals(result, ResultUtil.getFirst(result));
 	}
 	
 	/**
@@ -65,7 +71,7 @@ public class ResultUtilTest {
 	@Test
 	@Verifies(value = "should return null if the passed in result is null", method = "convert(CalculationResult,Class<T>)")
 	public void convert_shouldReturnNullIfThePassedInResultIsNull() throws Exception {
-		Assert.assertNull(ResultUtil.convert(null, String.class));
+		assertNull(ResultUtil.convert(null, String.class));
 	}
 	
 	/**
@@ -76,8 +82,8 @@ public class ResultUtilTest {
 	@Verifies(value = "should return an empty collection if the result has a null value and class is a list", method = "convert(CalculationResult,Class<T>)")
 	public void convert_shouldReturnAnEmptyCollectionIfTheResultHasANullValueAndClassIsAList() throws Exception {
 		List list = ResultUtil.convert(new SimpleResult(null, null), List.class);
-		Assert.assertNotNull(list);
-		Assert.assertTrue(list.isEmpty());
+		assertNotNull(list);
+		assertTrue(list.isEmpty());
 	}
 	
 	/**
@@ -88,8 +94,8 @@ public class ResultUtilTest {
 	@Verifies(value = "should return an empty collection if the result is null and class is a list", method = "convert(CalculationResult,Class<T>)")
 	public void convert_shouldReturnAnEmptyCollectionIfTheResultIsNullAndClassIsAList() throws Exception {
 		List list = ResultUtil.convert(null, List.class);
-		Assert.assertNotNull(list);
-		Assert.assertTrue(list.isEmpty());
+		assertNotNull(list);
+		assertTrue(list.isEmpty());
 	}
 	
 	/**
@@ -100,8 +106,8 @@ public class ResultUtilTest {
 	@Verifies(value = "should return an empty map if the result has a null value and class is a map", method = "convert(CalculationResult,Class<T>)")
 	public void convert_shouldReturnAnEmptyMapIfTheResultHasANullValueAndClassIsAMap() throws Exception {
 		Map map = ResultUtil.convert(new SimpleResult(null, null), Map.class);
-		Assert.assertNotNull(map);
-		Assert.assertTrue(map.isEmpty());
+		assertNotNull(map);
+		assertTrue(map.isEmpty());
 	}
 	
 	/**
@@ -112,8 +118,8 @@ public class ResultUtilTest {
 	@Verifies(value = "should return an empty map if the result is null and class is a map", method = "convert(CalculationResult,Class<T>)")
 	public void convert_shouldReturnAnEmptyMapIfTheResultIsNullAndClassIsAMap() throws Exception {
 		Map map = ResultUtil.convert(null, Map.class);
-		Assert.assertNotNull(map);
-		Assert.assertTrue(map.isEmpty());
+		assertNotNull(map);
+		assertTrue(map.isEmpty());
 	}
 	
 	/**
@@ -124,8 +130,8 @@ public class ResultUtilTest {
 	@Verifies(value = "should return an empty collection if the result has a null value and class is a set", method = "convert(CalculationResult,Class<T>)")
 	public void convert_shouldReturnAnEmptyCollectionIfTheResultHasANullValueAndClassIsASet() throws Exception {
 		Set set = ResultUtil.convert(new SimpleResult(null, null), Set.class);
-		Assert.assertNotNull(set);
-		Assert.assertTrue(set.isEmpty());
+		assertNotNull(set);
+		assertTrue(set.isEmpty());
 	}
 	
 	/**
@@ -136,8 +142,8 @@ public class ResultUtilTest {
 	@Verifies(value = "should return an empty collection if the result is null and class is a set", method = "convert(CalculationResult,Class<T>)")
 	public void convert_shouldReturnAnEmptyCollectionIfTheResultIsNullAndClassIsASet() throws Exception {
 		Set set = ResultUtil.convert(null, Set.class);
-		Assert.assertNotNull(set);
-		Assert.assertTrue(set.isEmpty());
+		assertNotNull(set);
+		assertTrue(set.isEmpty());
 	}
 
 	/**
@@ -146,7 +152,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnTrueForNull() throws Exception {
-	    Assert.assertTrue(ResultUtil.isFalse(null));
+	    assertTrue(ResultUtil.isFalse(null));
     }
 
 	/**
@@ -155,7 +161,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnTrueForAnEmptyCollection() throws Exception {
-    	Assert.assertTrue(ResultUtil.isFalse(new ArrayList<String>()));
+    	assertTrue(ResultUtil.isFalse(new ArrayList<String>()));
     }
 
 	/**
@@ -164,7 +170,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnFalseForANonemptyCollection() throws Exception {
-    	Assert.assertFalse(ResultUtil.isFalse(Collections.singleton("Not Empty")));
+    	assertFalse(ResultUtil.isFalse(Collections.singleton("Not Empty")));
     }
 
 	/**
@@ -173,7 +179,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnTrueForAnEmptyMap() throws Exception {
-    	Assert.assertTrue(ResultUtil.isFalse(new HashMap<String, Object>()));
+    	assertTrue(ResultUtil.isFalse(new HashMap<String, Object>()));
     }
 
 	/**
@@ -184,7 +190,7 @@ public class ResultUtilTest {
     public void isFalse_shouldReturnFalseForANonemptyMap() throws Exception {
     	Map<String, Object> map = new HashMap<String, Object>();
     	map.put("not", "empty");
-    	Assert.assertFalse(ResultUtil.isFalse(map));
+    	assertFalse(ResultUtil.isFalse(map));
     }
 
 	/**
@@ -193,7 +199,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnTrueForAnEmptyString() throws Exception {
-    	Assert.assertTrue(ResultUtil.isFalse(""));
+    	assertTrue(ResultUtil.isFalse(""));
     }
 
 	/**
@@ -202,7 +208,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnFalseForANonemptyString() throws Exception {
-    	Assert.assertFalse(ResultUtil.isFalse("Not empty"));
+    	assertFalse(ResultUtil.isFalse("Not empty"));
     }
 
 	/**
@@ -211,9 +217,9 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnTrueForTheNumber0() throws Exception {
-    	Assert.assertTrue(ResultUtil.isFalse(0));
-    	Assert.assertTrue(ResultUtil.isFalse(0d));
-    	Assert.assertTrue(ResultUtil.isFalse(BigDecimal.ZERO));
+    	assertTrue(ResultUtil.isFalse(0));
+    	assertTrue(ResultUtil.isFalse(0d));
+    	assertTrue(ResultUtil.isFalse(BigDecimal.ZERO));
     }
 
 	/**
@@ -222,9 +228,9 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnFalseForANonzeroNumber() throws Exception {
-    	Assert.assertFalse(ResultUtil.isFalse(-1));
-    	Assert.assertFalse(ResultUtil.isFalse(10d));
-    	Assert.assertFalse(ResultUtil.isFalse(BigDecimal.ONE));
+    	assertFalse(ResultUtil.isFalse(-1));
+    	assertFalse(ResultUtil.isFalse(10d));
+    	assertFalse(ResultUtil.isFalse(BigDecimal.ONE));
     }
 
 	/**
@@ -236,7 +242,7 @@ public class ResultUtilTest {
     	Obs obs = new Obs();
     	obs.setConcept(mockConcept(ConceptDatatype.NUMERIC_UUID));
     	obs.setValueNumeric(0d);
-    	Assert.assertTrue(ResultUtil.isFalse(obs));
+    	assertTrue(ResultUtil.isFalse(obs));
     }
 
 	/**
@@ -248,7 +254,7 @@ public class ResultUtilTest {
     	Obs obs = new Obs();
     	obs.setConcept(mockConcept(ConceptDatatype.NUMERIC_UUID));
     	obs.setValueNumeric(-1d);
-    	Assert.assertFalse(ResultUtil.isFalse(obs));
+    	assertFalse(ResultUtil.isFalse(obs));
     }
 
 	/**
@@ -260,7 +266,7 @@ public class ResultUtilTest {
     	Obs obs = new Obs();
     	obs.setConcept(mockConcept(ConceptDatatype.TEXT_UUID));
     	obs.setValueText("");
-    	Assert.assertTrue(ResultUtil.isFalse(obs));
+    	assertTrue(ResultUtil.isFalse(obs));
     }
 
 	/**
@@ -272,7 +278,7 @@ public class ResultUtilTest {
     	Obs obs = new Obs();
     	obs.setConcept(mockConcept(ConceptDatatype.TEXT_UUID));
     	obs.setValueText("not empty");
-    	Assert.assertFalse(ResultUtil.isFalse(obs));
+    	assertFalse(ResultUtil.isFalse(obs));
     }
 
 	/**
@@ -285,7 +291,7 @@ public class ResultUtilTest {
     	Obs obs = Mockito.mock(Obs.class);
     	Mockito.when(obs.getValueAsBoolean()).thenReturn(Boolean.FALSE);
     	Mockito.when(obs.getConcept()).thenReturn(mockConcept(ConceptDatatype.CODED_UUID));
-    	Assert.assertTrue(ResultUtil.isFalse(obs));
+    	assertTrue(ResultUtil.isFalse(obs));
     }
 
 	/**
@@ -299,7 +305,7 @@ public class ResultUtilTest {
     	// in 1.7 the test should do this instead on mocking getValueCoded
     	Mockito.when(obs.getValueAsBoolean()).thenReturn(null);
     	Mockito.when(obs.getConcept()).thenReturn(mockConcept(ConceptDatatype.CODED_UUID));
-    	Assert.assertFalse(ResultUtil.isFalse(obs));
+    	assertFalse(ResultUtil.isFalse(obs));
     }
 
 	/**
@@ -311,7 +317,7 @@ public class ResultUtilTest {
     	Obs obs = Mockito.mock(Obs.class);
     	Mockito.when(obs.getValueAsBoolean()).thenReturn(Boolean.FALSE);
     	Mockito.when(obs.getConcept()).thenReturn(mockConcept(ConceptDatatype.BOOLEAN_UUID));
-    	Assert.assertTrue(ResultUtil.isFalse(obs));
+    	assertTrue(ResultUtil.isFalse(obs));
     }
 
 	/**
@@ -323,7 +329,7 @@ public class ResultUtilTest {
     	Obs obs = Mockito.mock(Obs.class);
     	Mockito.when(obs.getValueAsBoolean()).thenReturn(Boolean.TRUE);
     	Mockito.when(obs.getConcept()).thenReturn(mockConcept(ConceptDatatype.BOOLEAN_UUID));
-    	Assert.assertFalse(ResultUtil.isFalse(obs));
+    	assertFalse(ResultUtil.isFalse(obs));
     }
     
 	/**
@@ -346,7 +352,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnTrueForAnEmptyListResult() throws Exception {
-    	Assert.assertTrue(ResultUtil.isFalse(new ListResult()));
+    	assertTrue(ResultUtil.isFalse(new ListResult()));
     }
 
 	/**
@@ -357,7 +363,7 @@ public class ResultUtilTest {
     public void isFalse_shouldReturnFalseForNonemptyListResult() throws Exception {
     	ListResult r = new ListResult();
     	r.add(new SimpleResult("not empty", null));
-    	Assert.assertFalse(ResultUtil.isFalse(r));
+    	assertFalse(ResultUtil.isFalse(r));
     }
 
 	/**
@@ -367,7 +373,7 @@ public class ResultUtilTest {
     @Test
     public void isFalse_shouldReturnTrueForAnEmptySimpleResult() throws Exception {
     	// it's bad practice to have a SimpleResult whose value is null, but we should still handle the case 
-    	Assert.assertTrue(ResultUtil.isFalse(new SimpleResult(null, null)));
+    	assertTrue(ResultUtil.isFalse(new SimpleResult(null, null)));
     }
 
 	/**
@@ -376,7 +382,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isFalse_shouldReturnFalseForANonemptySimpleResult() throws Exception {
-    	Assert.assertFalse(ResultUtil.isFalse(new SimpleResult(new PatientProgram(), null)));
+    	assertFalse(ResultUtil.isFalse(new SimpleResult(new PatientProgram(), null)));
     }
 
 	/**
@@ -385,7 +391,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isEmpty_shouldReturnTrueForNull() throws Exception {
-	    Assert.assertTrue(ResultUtil.isEmpty(null));
+	    assertTrue(ResultUtil.isEmpty(null));
     }
 
 	/**
@@ -394,7 +400,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isEmpty_shouldReturnTrueForEmptyCollections() throws Exception {
-    	Assert.assertTrue(ResultUtil.isEmpty(Collections.EMPTY_LIST));
+    	assertTrue(ResultUtil.isEmpty(Collections.EMPTY_LIST));
     }
 
 	/**
@@ -403,7 +409,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isEmpty_shouldReturnTrueForEmptyMaps() throws Exception {
-    	Assert.assertTrue(ResultUtil.isEmpty(Collections.EMPTY_MAP));
+    	assertTrue(ResultUtil.isEmpty(Collections.EMPTY_MAP));
     }
 
 	/**
@@ -412,7 +418,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isEmpty_shouldReturnFalseForNonemptyCollections() throws Exception {
-    	Assert.assertFalse(ResultUtil.isEmpty(Collections.singleton("not empty")));
+    	assertFalse(ResultUtil.isEmpty(Collections.singleton("not empty")));
     }
 
 	/**
@@ -423,7 +429,7 @@ public class ResultUtilTest {
     public void isEmpty_shouldReturnFalseForNonemptyMaps() throws Exception {
     	Map<String, Object> map = new HashMap<String, Object>();
     	map.put("not", "empty");
-    	Assert.assertFalse(ResultUtil.isEmpty(map));
+    	assertFalse(ResultUtil.isEmpty(map));
     }
 
 	/**
@@ -432,7 +438,7 @@ public class ResultUtilTest {
      */
     @Test
     public void isEmpty_shouldReturnFalseForPlainObjects() throws Exception {
-    	Assert.assertFalse(ResultUtil.isEmpty(-1));
+    	assertFalse(ResultUtil.isEmpty(-1));
     }
 
 	/**
@@ -441,7 +447,7 @@ public class ResultUtilTest {
      */
     @Test
     public void convert_shouldReturnTrueWhenConvertingAnArbitraryObjectToBoolean() throws Exception {
-	    Assert.assertTrue(ResultUtil.convert(new SimpleResult(new PatientProgram(), null), Boolean.class));
+	    assertTrue(ResultUtil.convert(new SimpleResult(new PatientProgram(), null), Boolean.class));
     }
 
 	/**
@@ -452,7 +458,7 @@ public class ResultUtilTest {
     public void convert_shouldReturnFalseWhenConvertingFalseyValuesToBoolean() throws Exception {
     	Object[] falsey = new Object[] { "", 0, 0d, Boolean.FALSE, null };
     	for (Object f : falsey) {
-    		Assert.assertFalse(ResultUtil.convert(new SimpleResult(f, null), Boolean.class));
+    		assertFalse(ResultUtil.convert(new SimpleResult(f, null), Boolean.class));
     	}
     }
     

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>legacyui-omod</artifactId>
-			<version>1.22.0</version>
+			<version>3.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/omod/src/main/java/org/openmrs/calculation/web/controller/CalculationAutoRegistrationFormController.java
+++ b/omod/src/main/java/org/openmrs/calculation/web/controller/CalculationAutoRegistrationFormController.java
@@ -47,7 +47,8 @@ public class CalculationAutoRegistrationFormController {
 	
 	/**
 	 */
-	@RequestMapping(value = "/module/calculation/calculationAutoRegistration", method = RequestMethod.GET)
+	@RequestMapping(value = { "/module/calculation/calculationAutoRegistration",
+	        "/module/calculation/calculationAutoRegistration.form" }, method = RequestMethod.GET)
 	public void showForm(Model model) {
 		List<CalculationRegistrationSuggestion> l  = Context.getRegisteredComponents(CalculationRegistrationSuggestion.class);
 		model.addAttribute("suggestions", l);
@@ -56,7 +57,8 @@ public class CalculationAutoRegistrationFormController {
 	/**
 	 * Attempt to auto-register any select groups of Calculations
 	 */
-	@RequestMapping(value = "/module/calculation/calculationAutoRegistration", method = RequestMethod.POST)
+	@RequestMapping(value = { "/module/calculation/calculationAutoRegistration",
+	        "/module/calculation/calculationAutoRegistration.form" }, method = RequestMethod.POST)
 	public String handleSubmission(WebRequest request,
 			@RequestParam(value="conflictMode", required=true) String conflictMode) {
 		

--- a/omod/src/main/java/org/openmrs/calculation/web/controller/CalculationRegistrationController.java
+++ b/omod/src/main/java/org/openmrs/calculation/web/controller/CalculationRegistrationController.java
@@ -15,7 +15,7 @@ package org.openmrs.calculation.web.controller;
 
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Cohort;
@@ -42,7 +42,8 @@ public class CalculationRegistrationController {
 	/**
 	 * Shows the page to list token registrations
 	 */
-	@RequestMapping(value = "/module/calculation/calculationRegistrations")
+	@RequestMapping(value = { "/module/calculation/calculationRegistrations",
+	        "/module/calculation/calculationRegistrations.list" })
 	public void listCalculationRegistrations(Model model) {
 		CalculationRegistrationService calculationRegistrationService = Context.getService(CalculationRegistrationService.class);
 		model.addAttribute("calculationRegistrations", calculationRegistrationService.getAllCalculationRegistrations());
@@ -51,7 +52,8 @@ public class CalculationRegistrationController {
 	/**
 	 * Page which tests patient calculations
 	 */
-	@RequestMapping(value = "/module/calculation/patientCalculationTest")
+	@RequestMapping(value = { "/module/calculation/patientCalculationTest",
+	        "/module/calculation/patientCalculationTest.form" })
 	public void patientCalculationTest(Model model,
 									   @RequestParam(value="id", required=true) Integer id,
 									   @RequestParam(value="patientIds", required=false) String patientIds,

--- a/omod/src/main/java/org/openmrs/calculation/web/controller/CalculationRegistrationFormController.java
+++ b/omod/src/main/java/org/openmrs/calculation/web/controller/CalculationRegistrationFormController.java
@@ -89,7 +89,8 @@ public class CalculationRegistrationFormController {
 	
 	/**
 	 */
-	@RequestMapping(value = "/module/calculation/calculationRegistration", method = RequestMethod.GET)
+	@RequestMapping(value = { "/module/calculation/calculationRegistration",
+	        "/module/calculation/calculationRegistration.form" }, method = RequestMethod.GET)
 	public void showCalculationRegistration() {
 		// Intentionally left blank. All work is done in the formBackingObject() method 
 	}
@@ -99,7 +100,8 @@ public class CalculationRegistrationFormController {
 	 * occurred it will populate binding result with corresponding error messages and return back to
 	 * edit page.
 	 */
-	@RequestMapping(value = "/module/calculation/calculationRegistration", method = RequestMethod.POST)
+	@RequestMapping(value = { "/module/calculation/calculationRegistration",
+	        "/module/calculation/calculationRegistration.form" }, method = RequestMethod.POST)
 	public String saveCalculationRegistration(@ModelAttribute("calculationRegistration") CalculationRegistration calculationRegistration,
 	                                          BindingResult result, WebRequest request) {
 		
@@ -128,7 +130,8 @@ public class CalculationRegistrationFormController {
 	/**
 	 * Purges given token registration and redirects to the list of existing ones
 	 */
-	@RequestMapping(value = "/module/calculation/deleteCalculationRegistration")
+	@RequestMapping(value = { "/module/calculation/deleteCalculationRegistration",
+	        "/module/calculation/deleteCalculationRegistration.form" })
 	public String purgeCalculationRegistration(@ModelAttribute(value = "calculationRegistration") CalculationRegistration calculationRegistration) {
 		Context.getService(CalculationRegistrationService.class).purgeCalculationRegistration(calculationRegistration);
 		return "redirect:calculationRegistrations.list";

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -13,15 +13,14 @@
 	<updateURL>
 		https://dev.openmrs.org/modules/download/${project.parent.artifactId}/update.rdf
 	</updateURL>
-	<require_version>1.11.3, 1.10.2 - 1.10.*, 1.9.9 - 1.9.*</require_version>
+	<require_version>3.0.0</require_version>
 	<!-- Change the require version back to the below, and update the openMRSVersion property accordingly when 1.6.6 is released -->
 	<!-- require_version>${openMRSVersion}</require_version -->
 	<!-- / Module Properties -->
 
 	<aware_of_modules>
-	    <aware_of_module>org.openmrs.module.legacyui</aware_of_module>
+		<aware_of_module>org.openmrs.module.legacyui</aware_of_module>
 	</aware_of_modules>
-
 	<!-- Module Activator -->
 	<activator>org.openmrs.${project.parent.artifactId}.CalculationActivator</activator>
 	

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -9,4 +9,5 @@
            http://www.springframework.org/schema/context/spring-context-2.5.xsd
            http://www.springframework.org/schema/util
            http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+	<context:component-scan base-package="org.openmrs.calculation.web.controller"/>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -34,91 +34,55 @@
 	</modules>
 
 	<properties>
-		<openMRSVersion>2.7.0</openMRSVersion>
+		<openMRSVersion>3.0.0-SNAPSHOT</openMRSVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<groovyVersion>2.4.21</groovyVersion>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
 
-			<!-- Libraries to add as dependencies with compile or runtime scope: Find 
-				matching dependencies in the maven central repository. <dependency> <groupId>org.other.library</groupId> 
-				<artifactId>library-name</artifactId> <version>library.version</version> 
+			<!-- Libraries to add as dependencies with compile or runtime scope: Find
+				matching dependencies in the maven central repository. <dependency> <groupId>org.other.library</groupId>
+				<artifactId>library-name</artifactId> <version>library.version</version>
 				<scope>compile</scope> </dependency> -->
 			<!-- Begin OpenMRS core -->
 
 			<dependency>
-				<groupId>org.openmrs.api</groupId>
-				<artifactId>openmrs-api</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>jar</type>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.web</groupId>
-				<artifactId>openmrs-web</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>jar</type>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.api</groupId>
-				<artifactId>openmrs-api</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>test-jar</type>
-				<scope>test</scope>
-
-				<exclusions>
-					<exclusion>
-						<groupId>org.powermock</groupId>
-						<artifactId>powermock-api-mockito2</artifactId>
-					</exclusion>
-
-					<exclusion>
-						<groupId>org.powermock</groupId>
-						<artifactId>powermock-api-mockito</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.web</groupId>
-				<artifactId>openmrs-web</artifactId>
-				<version>${openMRSVersion}</version>
-				<type>test-jar</type>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.openmrs.test</groupId>
-				<artifactId>openmrs-test</artifactId>
+				<groupId>org.openmrs</groupId>
+				<artifactId>openmrs-bom</artifactId>
 				<version>${openMRSVersion}</version>
 				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.openmrs.api</groupId>
+				<artifactId>openmrs-api</artifactId>
+				<version>${openMRSVersion}</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.openmrs.web</groupId>
+				<artifactId>openmrs-web</artifactId>
+				<version>${openMRSVersion}</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.openmrs.web</groupId>
+				<artifactId>openmrs-web</artifactId>
+				<version>${openMRSVersion}</version>
+				<type>test-jar</type>
 				<scope>test</scope>
-
-				<exclusions>
-					<exclusion>
-						<groupId>org.powermock</groupId>
-						<artifactId>powermock-api-mockito2</artifactId>
-					</exclusion>
-
-					<exclusion>
-						<groupId>org.powermock</groupId>
-						<artifactId>powermock-api-mockito</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 
 			<!-- End OpenMRS core -->
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-all</artifactId>
-				<version>${groovyVersion}</version>
 				<scope>provided</scope>
-				<type>jar</type>
 			</dependency>
 
 		</dependencies>
@@ -130,15 +94,15 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.15.0</version>
 					<configuration>
-						<target>8</target>
-						<source>8</source>
+						<release>${maven.compiler.release}</release>
 					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.11.2</version>
+					<version>3.12.0</version>
 					<configuration>
 						<additionalJOption>-Xdoclint:none</additionalJOption>
 					</configuration>
@@ -159,12 +123,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>2.4</version>
+					<version>3.11.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.4</version>
+					<version>3.5.1</version>
 					<executions>
 						<execution>
 							<goals>
@@ -176,7 +140,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>@{project.version}</tagNameFormat>


### PR DESCRIPTION
This PR upgrades the calculation module to support platform 3.x including upgrading to JDK 21.

Resolves ticket: https://openmrs.atlassian.net/browse/CALC-59

**Changes Summary**

- Use OpenMRS BOM from core, so many pinned versions are removed to sync with core
- Update legacy UI to 3.0.0
- Replace commons lang 2 with commons lang 3
- Hibernate migrations away from criterion to new criteria builder
- Migrated junit 4 to 5
- Removed web from api as it was causing some spring context issues and didn't seem to be used in api

**Possible issues**

- I added `<context:component-scan base-package="org.openmrs.calculation.web.controller"/>` because it wasn't picking this up, let me know if this is the wrong solution or if I could be missing something with this one.

**Testing**

- Ran unit tests and all passing
- Ran the calculation module with core 3.0.0 snapshot and the legacy UI. I was able to create and use a custom calculation on the UI. See JIRA for screenshots.